### PR TITLE
Add support for Object Cache Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ createproject
     4. [Getting started](#getting-started)
     5. [Paid or Premium plugins](#paid-or-premium-plugins)
         1. [Advanced Custom Fields Pro](#advanced-custom-fields-pro)
-        2. [Polylang Pro](#polylang-pro)
+        2. [Object Cache Pro](#object-cache-pro)
+        3. [Polylang Pro](#polylang-pro)
     6. [WP-CLI alias](#wp-cli-alias)
     7. [SEO Plugin](#seo-plugin)
     8. [Issues](#issues)
@@ -172,6 +173,23 @@ Then to "requires":
 
 ```json
     "advanced-custom-fields/advanced-custom-fields-pro": "5.9.4",
+```
+
+### Object Cache Pro
+
+Add to "repositories":
+
+```json
+{
+  "type": "composer",
+  "url": "https://xxx-organization-xxx:xxx-token-xxx@rhubarbgroup.repo.packagist.com/xxx-organization-xxx/"
+}
+```
+
+Then to "requires":
+
+```json
+"rhubarbgroup/object-cache-pro": "^1.13.0
 ```
 
 ### Polylang Pro

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Then to "requires":
 
 ### Object Cache Pro
 
+You will need Redis and PHP Redis installed in order to install this package.
+
 Add to "repositories":
 
 ```json

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,6 @@
     "wpackagist-plugin/simple-history": "*",
     "wpackagist-plugin/sendgrid-email-delivery-simplified": "*",
     "wpackagist-plugin/worker": "*",
-    "wpackagist-plugin/redis-cache": "*",
     "wpackagist-plugin/autodescription": "*",
     "wpackagist-plugin/gravity-forms-wcag-20-form-fields": "*"
   },

--- a/config/application.php
+++ b/config/application.php
@@ -110,6 +110,31 @@ Config::define( 'SCRIPT_DEBUG', false );
 ini_set( 'display_errors', '0' );
 
 /**
+ *  Redis object cache settings for
+ *  https://objectcache.pro/docs/configuration-options/
+ */
+Config::define( 'WP_REDIS_CONFIG', [
+  'token'             => env( 'REDIS_TOKEN' ),
+  'host'              => '127.0.0.1',
+  'port'              => 6379,
+  'password'          => env( 'REDIS_PASSWORD' ),
+  'prefix'            => env( 'DB_NAME' ),
+  'database'          => 0,
+  'maxttl'            => 43200, // max cache half day
+  'timeout'           => 1.0,
+  'read_timeout'      => 1.0,
+  'split_alloptions'  => true,
+  'async_flush'       => true,
+  'debug'             => false,
+] );
+
+if ( 'production' === WP_ENV ) {
+  Config::define( 'WP_REDIS_DISABLED', false );
+} else {
+  Config::define( 'WP_REDIS_DISABLED', true );
+}
+
+/**
  * Allow WordPress to detect HTTPS when used behind a reverse proxy or a load balancer
  * See https://codex.wordpress.org/Function_Reference/is_ssl#Notes
  */
@@ -130,16 +155,4 @@ Config::apply();
  */
 if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', $webroot_dir . '/wp/' );
-}
-
-/**
- *  Redis object cache settings for
- *  https://wordpress.org/plugins/redis-cache/
- */
-Config::define( 'WP_REDIS_PREFIX', getenv( 'DB_NAME' ) );
-Config::define( 'WP_REDIS_SELECTIVE_FLUSH', true );
-Config::define( 'WP_REDIS_MAXTTL', 43200 ); // max cache half day
-
-if ( 'development' !== WP_ENV ) {
-  Config::define( 'WP_REDIS_PASSWORD', getenv( 'REDIS_PASSWORD' ) );
 }

--- a/config/application.php
+++ b/config/application.php
@@ -119,7 +119,7 @@ Config::define( 'WP_REDIS_CONFIG', [
   'port'              => 6379,
   'password'          => env( 'REDIS_PASSWORD' ),
   'prefix'            => env( 'DB_NAME' ),
-  'database'          => 0,
+  'database'          => env( 'REDIS_DATABASE' ) ?: 0,
   'maxttl'            => 43200, // max cache half day
   'timeout'           => 1.0,
   'read_timeout'      => 1.0,


### PR DESCRIPTION
We've been using [Redis Object Cache](https://wordpress.org/plugins/redis-cache/) plugin for a long time, but recently bought a license for [Object Cache Pro](https://objectcache.pro/) which is a slightly better version of the plugin.

In this PR:
* Add instructions on how to add Object Cache Pro plugin project from private repo via composer
* Change the old configuration constant to a new one, which supports more settings

See [related PR](https://github.com/digitoimistodude/macos-lemp-setup/pull/7) in the macos-lemp-setup repo, as `object-cache-pro` package needs PHP extension in order it to successfully install via composer.